### PR TITLE
:sparkles: Add Ogpr.load api

### DIFF
--- a/lib/ogpr.rb
+++ b/lib/ogpr.rb
@@ -2,18 +2,33 @@
 
 require 'ogpr/version'
 require_relative './ogpr/fetcher.rb'
+require_relative './ogpr/loader.rb'
 require_relative './ogpr/parser.rb'
 
 module Ogpr
   class << self
     # Fetch the url and parse meta data.
+    #
+    # @param url [String] the target URL to fetch TwitterCard/OpenGraph meta tags from.
+    # @return [Ogpr::Result] the result object which contains TwitterCard/OpenGraph tags.
     def fetch(url, options = {})
       result = Fetcher.fetch(url, options)
 
       Parser.parse(result.to_s)
     end
 
+    # Load the hash object
+    #
+    # @param hash [Hash] hash object which contains TwitterCard/OpenGraph tags.
+    # @return [Ogpr::Result] the result object which contains TwitterCard/OpenGraph tags.
+    def load(hash)
+      Loader.load(hash)
+    end
+
     # Parse the string
+    #
+    # @param str [String] html string which contains TwitterCard/OpenGraph meta tags.
+    # @return [Ogpr::Result] the result object which contains TwitterCard/OpenGraph tags.
     def parse(str, options = {})
       Parser.parse(str, options)
     end

--- a/lib/ogpr.rb
+++ b/lib/ogpr.rb
@@ -29,8 +29,8 @@ module Ogpr
     #
     # @param str [String] html string which contains TwitterCard/OpenGraph meta tags.
     # @return [Ogpr::Result] the result object which contains TwitterCard/OpenGraph tags.
-    def parse(str, options = {})
-      Parser.parse(str, options)
+    def parse(str)
+      Parser.parse(str)
     end
   end
 end

--- a/lib/ogpr/loader.rb
+++ b/lib/ogpr/loader.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative './result.rb'
+
+module Ogpr
+  class Loader
+    class << self
+      def load(hash)
+        Result.new(hash)
+      end
+    end
+  end
+end

--- a/spec/ogpr/loader_spec.rb
+++ b/spec/ogpr/loader_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Ogpr::Loader do
+  describe 'self.load' do
+    context 'with hash which contains twitter/og tags' do
+      let(:hash) do
+        {
+          'og:site_name' => 'sample page',
+          'og:title' => 'sample title',
+          'og:description' => 'sample page description',
+          'og:url' => 'https://example.com/page.html',
+          'og:image' => 'https://example.com/image.png',
+          'og:type' => 'article',
+          'twitter:card' => 'summary_large_image',
+          'twitter:site' => '@twitter',
+          'twitter:creator' => '@twitter'
+        }
+      end
+
+      it 'should return Ogpr::Result' do
+        result = Ogpr::Loader.load(hash)
+        expect(result).to be_an_instance_of(Ogpr::Result)
+
+        expect(result.meta).to eq(hash)
+
+        expect(result.open_graph).to be_an_instance_of(Ogpr::Model::OpenGraph)
+        expect(result.open_graph.meta).to eq(
+          hash.select {|k, _| k =~ /^og/}
+        )
+
+        expect(result.twitter_card).to be_an_instance_of(Ogpr::Model::TwitterCard)
+        expect(result.twitter_card.meta).to eq(
+          hash.select { |k, _| k =~ /^twitter/ }
+        )
+      end
+    end
+  end
+end

--- a/spec/ogpr/parser_spec.rb
+++ b/spec/ogpr/parser_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe Ogpr::Parser do
           'og:description' => 'sample page description',
           'og:url' => 'https://example.com/page.html',
           'og:image' => 'https://example.com/image.png',
-          'og:type' => 'article',
-
+          'og:type' => 'article'
         })
 
         expect(result.twitter_card).to be_an_instance_of(Ogpr::Model::TwitterCard)

--- a/spec/ogpr_spec.rb
+++ b/spec/ogpr_spec.rb
@@ -1,10 +1,67 @@
 RSpec.describe Ogpr do
-  describe 'fetch' do
-    pending 'TODO add testcase'
+  describe 'self.fetch' do
+    before do
+      WebMock.enable!
+      stub_request(:get, /example.com/).to_rack(FakeServer)
+      stub_request(:head, /example.com/).to_rack(FakeServer)
+    end
+    after { WebMock.disable! }
+
+    context 'when the url does not found' do
+      it 'should throw error' do
+        expect { Ogpr.fetch('https://example.com/error/not_found') }.to raise_error(/Got http status code\(404\)/)
+      end
+    end
+
+    context 'when the content is a png file' do
+      it 'should throw error' do
+        expect { Ogpr.fetch('http://example.com/image.png').to raise_error(/Can't accept content-type: image\/png/) }
+      end
+    end
+
+    context 'when the content is pdf file' do
+      it 'should throw error' do
+        expect { Ogpr.fetch('http://example.com/file.pdf') }.to raise_error(/Can't accept content-type: application\/pdf/)
+      end
+    end
+
+    context 'when the content is a html file' do
+      it 'should return an Ogpr::Result instance' do
+        expect(Ogpr.fetch('http://example.com/page.html')).to be_an_instance_of(Ogpr::Result)
+      end
+    end
   end
 
-  describe 'parse' do
-    pending 'TODO add testcase'
+  describe 'self.load' do
+    context 'with a Hash object which contains TwitterCard/OpenGraph tags' do
+      let(:hash) do
+        {
+          'og:site_name' => 'sample page',
+          'og:title' => 'sample title',
+          'og:description' => 'sample page description',
+          'og:url' => 'https://example.com/page.html',
+          'og:image' => 'https://example.com/image.png',
+          'og:type' => 'article',
+          'twitter:card' => 'summary_large_image',
+          'twitter:site' => '@twitter',
+          'twitter:creator' => '@twitter'
+        }
+      end
+
+      it 'should return an Ogpr::Result instance' do
+        expect(Ogpr.load(hash)).to be_an_instance_of(Ogpr::Result)
+      end
+    end
+  end
+
+  describe 'self.parse' do
+    context 'with a html string which contains TwitterCard/OpenGraph meta tags' do
+      let(:html) { htmlContent('page.html') }
+
+      it 'should return an Ogpr::Result instance' do
+        expect(Ogpr.parse(html)).to be_an_instance_of(Ogpr::Result)
+      end
+    end
   end
 
   it "has a version number" do


### PR DESCRIPTION
This pull req add the API to load hash object, like this.

```ruby
Ogpr.load({"og:title" => "sample site"})
```