### PR TITLE
gemspec: Allow Bundler 2

### DIFF
--- a/ogpr.gemspec
+++ b/ogpr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17.3"
+  spec.add_development_dependency "bundler", ">= 1.17.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sinatra", "~> 2.0.1"


### PR DESCRIPTION
This PR makes the gemspec allow Bundler 2+ as well in the development dependencies.