### PR TITLE
Drop TravisCI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.5.0
-before_install: gem install bundler -v 1.16.1


### PR DESCRIPTION
This PR drops the Travis CI configuration file, now that CircleCI is up.