### PR TITLE
Replacing Rest Client w/HTTP

### DIFF
--- a/lib/ogpr/fetcher/html_fetcher.rb
+++ b/lib/ogpr/fetcher/html_fetcher.rb
@@ -32,11 +32,11 @@ module Ogpr
       end
 
       def send_request(method, uri, headers)
-        RestClient::Request.execute(
-          request_options(method, uri, headers)
-        )
-      rescue RestClient::ExceptionWithResponse => e
-        raise "Got http status code(#{e.response.code}) by #{method} request from #{uri}"
+        HTTP.headers(headers).send(method, uri).tap do |res|
+          next if res.status.success?
+
+          raise "Got http status code(#{res.status.code}) by #{method} request from #{uri}"
+        end
       rescue => e
         raise e
       end

--- a/lib/ogpr/fetcher/html_fetcher.rb
+++ b/lib/ogpr/fetcher/html_fetcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'uri'
-require 'rest-client'
+require 'http'
 require 'kconv'
 
 module Ogpr

--- a/lib/ogpr/fetcher/html_fetcher.rb
+++ b/lib/ogpr/fetcher/html_fetcher.rb
@@ -2,7 +2,6 @@
 
 require 'uri'
 require 'http'
-require 'kconv'
 
 module Ogpr
   class Fetcher
@@ -17,7 +16,7 @@ module Ogpr
         acceptable_content!(head.headers[:content_type])
 
         res = send_request(:get, @uri, headers)
-        Kconv.toutf8(res.to_str)
+        res.encode("UTF-8", invalid: :replace, undef: :replace)
       rescue => e
         raise e
       end

--- a/ogpr.gemspec
+++ b/ogpr.gemspec
@@ -19,15 +19,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17.3"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.17.3"
+  spec.add_development_dependency "rake", "~> 13.1.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "sinatra", "~> 2.0.1"
-  spec.add_development_dependency 'rubocop', '~> 0.52.1'
-  spec.add_development_dependency "webmock", "~> 3.3.0"
-  spec.add_development_dependency "simplecov", "~> 0.14.1"
-  spec.add_development_dependency "coveralls", "~> 0.8.21"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0"
-  spec.add_dependency 'rest-client', '~> 2.1.0'
+  spec.add_development_dependency "sinatra", "~> 4.0.0"
+  spec.add_development_dependency 'rubocop', "~> 1.60.2"
+  spec.add_development_dependency "webmock", "~> 3.20.0"
+  spec.add_development_dependency "simplecov", "~> 0.22.0"
+  spec.add_dependency 'http', '~> 5.2.0'
   spec.add_dependency 'nokogiri', '~> 1.8'
 end

--- a/ogpr.gemspec
+++ b/ogpr.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'http', '>= 5.2.0', '< 6.0.0'
+  spec.add_dependency 'nokogiri', '~> 1.8'
+
   spec.add_development_dependency "bundler", ">= 1.17.3"
   spec.add_development_dependency "rake", "~> 13.1.0"
   spec.add_development_dependency "rspec", "~> 3.0"
@@ -26,6 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', "~> 1.60.2"
   spec.add_development_dependency "webmock", "~> 3.20.0"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
-  spec.add_dependency 'http', '~> 5.2.0'
-  spec.add_dependency 'nokogiri', '~> 1.8'
 end


### PR DESCRIPTION
I wanted to knock out an out of date dependency of 'http-accept' being held back by Rest Client. This PR replaces Rest Client with HTTP but also updates every dependency to the latest version of everything.