### PR TITLE
remove Kconv.toutf8 conversion

### DIFF
--- a/lib/ogpr/fetcher/html_fetcher.rb
+++ b/lib/ogpr/fetcher/html_fetcher.rb
@@ -17,7 +17,6 @@ module Ogpr
         acceptable_content!(head.headers[:content_type])
 
         res = send_request(:get, @uri, headers)
-        Kconv.toutf8(res.to_str)
       rescue => e
         raise e
       end


### PR DESCRIPTION
In lib/ogpr/fetcher/html_fetcher.rb:20 the fetched meta tag content is forced to UTF-8 using the stdlib Kconv. This conversion seems unnecessary, but also introduces a lot of wrongly converted characters. In my use case, a lot of accented latin letters are converted to chinese characters. This also seems to happen with some punctuation.